### PR TITLE
Settable::Caster new options

### DIFF
--- a/lib/sinclair/settable.rb
+++ b/lib/sinclair/settable.rb
@@ -92,6 +92,11 @@ class Sinclair
     #   to be added
     # @param options [Hash<Symbol, Object>] setting exposition options
     # @option options type [Symbol] type to cast the value fetched
+    #   - integer: converts to Integer
+    #   - string: converts to String
+    #   - float: converts to Float
+    #   - seconds: converts to ActiveSupport::Duration in seconds
+    #   - boolean: converts to Boolean (true/false)
     # @option options default [Object] Default value
     # @option options cached [Boolean, Symbol] Flag informing if value
     #    is cached or not.

--- a/lib/sinclair/settable/caster.rb
+++ b/lib/sinclair/settable/caster.rb
@@ -56,6 +56,7 @@ class Sinclair
       cast_with(:integer, &:to_i)
       cast_with(:string, &:to_s)
       cast_with(:float, &:to_f)
+      cast_with(:seconds) { |value| value.to_i.seconds }
     end
   end
 end

--- a/lib/sinclair/settable/caster.rb
+++ b/lib/sinclair/settable/caster.rb
@@ -57,6 +57,7 @@ class Sinclair
       cast_with(:string, &:to_s)
       cast_with(:float, &:to_f)
       cast_with(:seconds) { |value| value.to_i.seconds }
+      cast_with(:boolean) { |value| value.to_s.downcase == 'true' }
     end
   end
 end

--- a/spec/lib/sinclair/settable/caster_spec.rb
+++ b/spec/lib/sinclair/settable/caster_spec.rb
@@ -34,6 +34,20 @@ describe Sinclair::Settable::Caster do
       end
     end
 
+    context 'when casting to seconds' do
+      it 'converts string to seconds duration' do
+        result = described_class.cast('300', :seconds)
+        expect(result).to eq(300.seconds)
+        expect(result).to be_a(ActiveSupport::Duration)
+      end
+
+      it 'converts integer to seconds duration' do
+        result = described_class.cast(60, :seconds)
+        expect(result).to eq(60.seconds)
+        expect(result).to be_a(ActiveSupport::Duration)
+      end
+    end
+
     context 'when casting with unknown type' do
       it 'returns the original value' do
         expect(described_class.cast('value', :unknown)).to eq('value')

--- a/spec/lib/sinclair/settable/caster_spec.rb
+++ b/spec/lib/sinclair/settable/caster_spec.rb
@@ -66,7 +66,7 @@ describe Sinclair::Settable::Caster do
       end
 
       it 'converts nil to boolean false' do
-        expect(described_class.cast('anything', :boolean)).to be false
+        expect(described_class.cast(nil, :boolean)).to be false
       end
     end
 

--- a/spec/lib/sinclair/settable/caster_spec.rb
+++ b/spec/lib/sinclair/settable/caster_spec.rb
@@ -36,15 +36,11 @@ describe Sinclair::Settable::Caster do
 
     context 'when casting to seconds' do
       it 'converts string to seconds duration' do
-        result = described_class.cast('300', :seconds)
-        expect(result).to eq(300.seconds)
-        expect(result).to be_a(ActiveSupport::Duration)
+        expect(described_class.cast('300', :seconds)).to eq(300.seconds)
       end
 
       it 'converts integer to seconds duration' do
-        result = described_class.cast(60, :seconds)
-        expect(result).to eq(60.seconds)
-        expect(result).to be_a(ActiveSupport::Duration)
+        expect(described_class.cast(60, :seconds)).to eq(60.seconds)
       end
     end
 

--- a/spec/lib/sinclair/settable/caster_spec.rb
+++ b/spec/lib/sinclair/settable/caster_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Sinclair::Settable::Caster do
+  describe '.cast' do
+    context 'when casting to integer' do
+      it 'converts string to integer' do
+        expect(described_class.cast('10', :integer)).to eq(10)
+      end
+
+      it 'converts float to integer' do
+        expect(described_class.cast(10.5, :integer)).to eq(10)
+      end
+    end
+
+    context 'when casting to string' do
+      it 'converts integer to string' do
+        expect(described_class.cast(10, :string)).to eq('10')
+      end
+
+      it 'converts symbol to string' do
+        expect(described_class.cast(:symbol, :string)).to eq('symbol')
+      end
+    end
+
+    context 'when casting to float' do
+      it 'converts string to float' do
+        expect(described_class.cast('10.5', :float)).to eq(10.5)
+      end
+
+      it 'converts integer to float' do
+        expect(described_class.cast(10, :float)).to eq(10.0)
+      end
+    end
+
+    context 'when casting with unknown type' do
+      it 'returns the original value' do
+        expect(described_class.cast('value', :unknown)).to eq('value')
+      end
+    end
+  end
+end

--- a/spec/lib/sinclair/settable/caster_spec.rb
+++ b/spec/lib/sinclair/settable/caster_spec.rb
@@ -48,6 +48,32 @@ describe Sinclair::Settable::Caster do
       end
     end
 
+    context 'when casting to boolean' do
+      it 'converts string "true" to boolean true' do
+        expect(described_class.cast('true', :boolean)).to be true
+      end
+
+      it 'converts string "TRUE" to boolean true' do
+        expect(described_class.cast('TRUE', :boolean)).to be true
+      end
+
+      it 'converts string "false" to boolean false' do
+        expect(described_class.cast('false', :boolean)).to be false
+      end
+
+      it 'converts string "FALSE" to boolean false' do
+        expect(described_class.cast('FALSE', :boolean)).to be false
+      end
+
+      it 'converts any other string to boolean false' do
+        expect(described_class.cast('anything', :boolean)).to be false
+      end
+
+      it 'converts nil to boolean false' do
+        expect(described_class.cast('anything', :boolean)).to be false
+      end
+    end
+
     context 'when casting with unknown type' do
       it 'returns the original value' do
         expect(described_class.cast('value', :unknown)).to eq('value')


### PR DESCRIPTION
## Add seconds and boolean casting types to Settable::Caster

This PR enhances the `Sinclair::Settable::Caster` with two new casting types to support common data conversion patterns.

### New Casting Types

- **`:seconds`** - Converts numeric values to `ActiveSupport::Duration` objects in seconds
- **`:boolean`** - Converts string values to boolean (`true`/`false`) with case-insensitive support

### Changes

- **Caster enhancement**: Added `:seconds` and `:boolean` casting methods to `Sinclair::Settable::Caster`
- **Documentation update**: Updated method documentation to include the new casting types
- **Test coverage**: Added comprehensive specs for both new casting types

### Usage Examples

```ruby
class MySettings
  extend Sinclair::EnvSettable
  
  setting_with_options :timeout, type: :seconds     # "300" -> 300.seconds
  setting_with_options :enabled, type: :boolean     # "true" -> true, "false" -> false
end

ENV['TIMEOUT'] = '120'
ENV['ENABLED'] = 'true'

MySettings.timeout  # returns 120.seconds (ActiveSupport::Duration)
MySettings.enabled  # returns true